### PR TITLE
Use GitVersion action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,7 +69,7 @@ jobs:
         file: .github/workflows/build.Dockerfile
         tags: gaip-net/packages:latest
         target: dotnet-pack
-        build-args: Version=${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }} 
+        build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
         load: true
       
     - name: Push to Nuget

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,12 +66,12 @@ jobs:
         tags: gaip-net/packages:latest
         target: export-packages
         build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
-        output: ${{ github.workspace }}/nupkgs
+        output: type=local,dest=${{ github.workspace }}/nupkgs
     
     # Only push on actual builds, not on PRs
     - name: Push to Nuget
       if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
-      run : |
+      run: |
         dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
         
     - name: Upload nupkg files

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,21 +64,15 @@ jobs:
       with:
         file: .github/workflows/build.Dockerfile
         tags: gaip-net/packages:latest
-        target: dotnet-pack
+        target: export-packages
         build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
-        load: true
+        output: ${{ github.workspace }}/nupkgs
     
     # Only push on actual builds, not on PRs
     - name: Push to Nuget
       if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
       run : |
-        docker run --name pack gaip-net/packages:latest dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
-        
-    - name: Copy nupkg files
-      id: copy-nupkgs
-      if: steps.package.outcome == 'success'
-      run : |
-        docker cp pack:/output ${{ github.workspace }}/nupkgs
+        dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
         
     - name: Upload nupkg files
       if: steps.copy-nupkgs.outcome == 'success'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: build-and-test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, prerelease ]
   pull_request:
-    branches: [ main ] 
+    branches: [ main, prerelease ] 
 
 jobs:
   build:
@@ -46,20 +46,20 @@ jobs:
     # Build and push packages           
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.13
+      if: github.event_name != 'pull_request'
       with:
         versionSpec: '5.x'
     
     - name: Checkout for version calculation
       uses: actions/checkout@v2
+      if: github.event_name != 'pull_request'
       with:
         fetch-depth: 0
         
     - name: Determine Version
       id:   gitversion
       uses: gittools/actions/gitversion/execute@v0.9.13
-    
-    - run: |
-        echo ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      if: github.event_name != 'pull_request'
     
     - uses: docker/build-push-action@v2.9.0
       id: package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,7 +75,7 @@ jobs:
         dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
         
     - name: Upload nupkg files
-      if: steps.copy-nupkgs.outcome == 'success'
+      if: steps.package.outcome == 'success'
       uses: actions/upload-artifact@v3
       with:
         name: nuget-packages

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Used later for calculating GitVersion
 
     - name: Docker Setup Buildx
       uses: docker/setup-buildx-action@v1.6.0
@@ -48,11 +50,6 @@ jobs:
       uses: gittools/actions/gitversion/setup@v0.9.13
       with:
         versionSpec: '5.x'
-    
-    - name: Checkout for version calculation
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
         
     - name: Determine Version
       id:   gitversion

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,34 +46,31 @@ jobs:
     # Build and push packages           
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.13
-      if: github.event_name != 'pull_request'
       with:
         versionSpec: '5.x'
     
     - name: Checkout for version calculation
       uses: actions/checkout@v2
-      if: github.event_name != 'pull_request'
       with:
         fetch-depth: 0
         
     - name: Determine Version
       id:   gitversion
       uses: gittools/actions/gitversion/execute@v0.9.13
-      if: github.event_name != 'pull_request'
     
     - uses: docker/build-push-action@v2.9.0
       id: package
       name: Prepare packages
-      if: github.event_name != 'pull_request'
       with:
         file: .github/workflows/build.Dockerfile
         tags: gaip-net/packages:latest
         target: dotnet-pack
         build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
         load: true
-      
+    
+    # Only push on actual builds, not on PRs
     - name: Push to Nuget
-      if: steps.package.outcome == 'success'
+      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
       run : |
         docker run --name pack gaip-net/packages:latest dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
         

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      # Used later for calculating GitVersion
       with:
-        fetch-depth: 0 # Used later for calculating GitVersion
+        fetch-depth: 0 
 
     - name: Docker Setup Buildx
       uses: docker/setup-buildx-action@v1.6.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,8 +44,8 @@ jobs:
       if: ${{ always() }}
       
     # Build and push packages           
-    - name: Install Git Version
-      uses: GitTools/actions@v0.9
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.13
       with:
         versionSpec: '6.x'
     
@@ -56,7 +56,7 @@ jobs:
         
     - name: Determine Version
       id:   gitversion
-      uses: gittools/actions/gitversion/execute@v0.9
+      uses: gittools/actions/gitversion/execute@v0.9.13
     
     - run: |
         echo ${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,17 +66,23 @@ jobs:
         target: export-packages
         build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
         outputs: type=local,dest=${{ github.workspace }}
-    
-    # Only push on actual builds, not on PRs
-    - name: Push to Nuget
-      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
-      run: |
-        dotnet nuget push ${{ github.workspace }}/nupkgs/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
-        
+
     - name: Upload nupkg files
       if: steps.package.outcome == 'success'
       uses: actions/upload-artifact@v3
       with:
         name: nuget-packages
         path: ${{ github.workspace }}/nupkgs
-      
+
+      # Only push on actual builds, not on PRs
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
+      with:
+        dotnet-version: |
+          6.0.x
+
+    - name: Push to Nuget
+      if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
+      run: |
+        dotnet nuget push ${{ github.workspace }}/nupkgs/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.13
       with:
-        versionSpec: '6.x'
+        versionSpec: '5.x'
     
     - name: Checkout for version calculation
       uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
       uses: gittools/actions/gitversion/execute@v0.9.13
     
     - run: |
-        echo ${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }}
+        echo ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     
     - uses: docker/build-push-action@v2.9.0
       id: package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,7 +63,6 @@ jobs:
       name: Prepare packages
       with:
         file: .github/workflows/build.Dockerfile
-        tags: gaip-net/packages:latest
         target: export-packages
         build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
         output: type=local,dest=${{ github.workspace }}/nupkgs
@@ -72,7 +71,7 @@ jobs:
     - name: Push to Nuget
       if: steps.package.outcome == 'success' && github.event_name != 'pull_request'
       run: |
-        dotnet nuget push /output/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
+        dotnet nuget push ${{ github.workspace }}/nupkgs/*.nupkg -k ${{ secrets.NUGET_PAT }} -s https://api.nuget.org/v3/index.json
         
     - name: Upload nupkg files
       if: steps.package.outcome == 'success'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
         file: .github/workflows/build.Dockerfile
         target: export-packages
         build-args: Version=${{ steps.gitversion.outputs.nuGetVersionV2 }} 
-        output: type=local,dest=${{ github.workspace }}/nupkgs
+        outputs: type=local,dest=${{ github.workspace }}
     
     # Only push on actual builds, not on PRs
     - name: Push to Nuget

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,23 @@ jobs:
       if: ${{ always() }}
       
     # Build and push packages           
+    - name: Install Git Version
+      uses: GitTools/actions@v0.9.13
+      with:
+        versionSpec: '6.x'
+    
+    - name: Checkout for version calculation
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        
+    - name: Determine Version
+      id:   gitversion
+      uses: gittools/actions/gitversion/execute@v0.9.7
+    
+    - run: |
+        echo ${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }}
+    
     - uses: docker/build-push-action@v2.9.0
       id: package
       name: Prepare packages
@@ -52,7 +69,7 @@ jobs:
         file: .github/workflows/build.Dockerfile
         tags: gaip-net/packages:latest
         target: dotnet-pack
-        build-args: Version=0.0.1-alpha.${{ github.run_number }} 
+        build-args: Version=${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }} 
         load: true
       
     - name: Push to Nuget

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
       
     # Build and push packages           
     - name: Install Git Version
-      uses: GitTools/actions@v0.9.13
+      uses: GitTools/actions@v0.9
       with:
         versionSpec: '6.x'
     
@@ -56,7 +56,7 @@ jobs:
         
     - name: Determine Version
       id:   gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.7
+      uses: gittools/actions/gitversion/execute@v0.9
     
     - run: |
         echo ${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }}

--- a/.github/workflows/build.Dockerfile
+++ b/.github/workflows/build.Dockerfile
@@ -45,4 +45,4 @@ RUN dotnet pack ./src/Gaip.Net.Linq/Gaip.Net.Linq.csproj --no-build --output /ou
 
 # Build stage for exporting locally. Not used in build pipelines for now.
 FROM scratch AS export-packages
-COPY --from=dotnet-pack /output .
+COPY --from=dotnet-pack /output /nupkgs

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1,1 +1,1 @@
-DOCKER_BUILDKIT=1 docker build -f ./.github/workflows/build.Dockerfile .  --build-arg Version="$1" --target export-packages --output output 
+docker buildx build -f ./.github/workflows/build.Dockerfile . --build-arg Version="$1" --target export-packages --output type=local,dest=. 


### PR DESCRIPTION
Includes an optimization where we export only the nuget packages, and simply push them instead of doing docker loads to load the whole package, then run the entire container just to push the packages.